### PR TITLE
Ensure all remaing strategies are valid options

### DIFF
--- a/src/Language/Tokenizer/Finder/TokenFinder.php
+++ b/src/Language/Tokenizer/Finder/TokenFinder.php
@@ -72,8 +72,29 @@ class TokenFinder implements TokenFinderInterface
             throw new UnexpectedTokenSequenceException($sequence);
         }
 
-        $strategy = reset($previous);
+        $sequence = substr($sequence, 0, -1);
+        $token    = array_reduce(
+            $previous,
+            function (
+                ?TokenInterface $carry,
+                TokenStrategyInterface $strategy
+            ) use($sequence): ?TokenInterface {
+                if ($carry === null) {
+                    try {
+                        $carry = $strategy($sequence);
+                    } catch (UnexpectedTokenSequenceException $exception) {
+                        $carry = null;
+                    }
+                }
 
-        return $strategy(substr($sequence, 0, -1));
+                return $carry;
+            }
+        );
+
+        if ($token === null) {
+            throw new UnexpectedTokenSequenceException($sequence);
+        }
+
+        return $token;
     }
 }


### PR DESCRIPTION
When trying to resolve the (currently hypothetical) T_ADD token `+`, the
token will partially match the number strategy.

In the current setup, this makes the number strategy the top-most
remaining strategy left in the `$previous` array. Since only the
top-most remaining strategy is ever tried, the symbol strategy, that
will validate `+` on its own, never gets the chance to do so.

By reducing the `$previous` array until a token is found, the
performance is nigh equal to the previous situation, for all other
tokens, but allows a more comprehensive check for those tokens that need
it.