### PR TITLE
Get the current token, after nested expressions have parsed

### DIFF
--- a/src/Language/Parser/Parser.php
+++ b/src/Language/Parser/Parser.php
@@ -113,10 +113,10 @@ class Parser implements ParserInterface
         while ($symbol !== null
             && $bindingPower < $symbol->getBindingPower()
         ) {
-            $token   = $context->advance();
+            $context->advance();
             $left    = $symbol->led($context, $subject, $left);
-            $symbol  = $this->symbols->getSymbol($token);
-            $subject = $token;
+            $subject = $context->current();
+            $symbol  = $this->symbols->getSymbol($subject);
         }
 
         return $left;


### PR DESCRIPTION
Because `$symbol->led` is likely to parse additional expressions, the current token may have changed since it was invoked. Therefore, the token is read after this function call.